### PR TITLE
Version 3.1.2 Updates

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,31 +1,37 @@
 # CryptoShark
-Data Encryption Package for .NET 6
+## Cross Platform Data Encryption Package for .NET 9
 
 ## Version History
 **Version 1.0 - Initial Release**
-
 * Password Based Encryption
 * RSA Public/Private Key Encryption
 
-**Version 2.1 - Update March 2022**
-
+**Version 2.1**
 * .NET 6 Update
 * Added ECC Encryption 
 
-**Version 2.1.2 - Update April 2022**
+**Version 2.1.2**
 * Added back the ability to work with Pkcs8 Encrypted Keys
 
-**Version 3.0.0 - Update July 2025**
+**Version 3.0.0**
 * .NET 9 Update
 * Complete rewrite for easier use.
 * Supports logging via ILogger interface
 * Supports multiple forms of dependency injection
 
-**Version 3.1.0 - Update July 2025**
+**Version 3.1.0**
 * Replaced all .Net Ecc Cryptography Next Generation (CNG) with BouncyCastle code
 
-**Version 3.2.0 - Update July 2025**
+**Version 3.2.0**
 * Updated RSA Keys to use Encrypted PEM format same as ECC Keys
+* Replaced all .Net Rsa Cryptography Next Generation (CNG) with BouncyCastle code
+
+**Version 3.2.1**
+* Internal code updates to mke future enhaemnts easier
+* Exposed all the internal parts allowing supplying the desired options
+    * Hash Alorythm for verifying data integrity can now be chosen
+    * RSA Padding for RSA Encryption can now be set with stanard string 
+        * Example: 'OAEPWithSHA-256AndMGF1Padding'
 
 ## About
 Code written on macOS & Windows 11

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -21,8 +21,11 @@ Data Encryption Package for .NET 6
 * Supports logging via ILogger interface
 * Supports multiple forms of dependency injection
 
-*Version 3.1.0 - Update July 2025**
+**Version 3.1.0 - Update July 2025**
 * Replaced all .Net Ecc Cryptography Next Generation (CNG) with BouncyCastle code
+
+**Version 3.2.0 - Update July 2025**
+* Updated RSA Keys to use Encrypted PEM format same as ECC Keys
 
 ## About
 Code written on macOS & Windows 11
@@ -49,6 +52,7 @@ Designed to fit your workflow, all public classes have interfaces for easy depen
 
 ## Keys
 * As of 3.1 Ecc Keys are in the Encrypted PEM Format. Yu can use ones created elsewhere if you want even, simply read the PEM file into a byte array and pass it in as the Ecc Private Key along with the passwor. So this gives you the flexibity to use ones created elsewhere, i.e. open ssl.
+* As of 3.2 Rsa Keys are stored the same way.
 
 ### Example ECC PEM Key
 ```-----BEGIN EC PRIVATE KEY-----
@@ -67,6 +71,27 @@ XkUqRQJQfo6KvmLYQJ1whegrVxA5Eu3GRW1wfMF4/+PewyfRp9JqtiFawEXpaM0w
 gKp8tdUKx2NMcvgDbpFgn1XenVuDN7pyZtsOWx5QDgphoL04hx27QGp4DbflshgA
 EeFw3nIc4Vq0OQozcUuanLgzeUT7e3hi2eW0Vm/n
 -----END EC PRIVATE KEY-----
+```
+
+### Example RSA PEM Key
+```-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: BF-OFB,45DAED7D531B4775
+
+mUsWdDxW3CoSAvat5ymXZNne0ZmhxRzXqRTwCtzgJLAJzTi+NY+VucVu2LoRgHX1
+Fmtp8EzRXzzPvxBanjSkwbdz36j97IUk+ZNxBCwFabR6P8BbFCCu36ZLlV41OT+C
+8UHy9/v41DVUOi5qYhqxzITEBiB0QC+pAuW+vo++ixcWMQzRFaFo8QTcnVaK2c4W
+hIIMbdaMaWh0qd9ElqSGA02YS9gcuE4DJF/aCq1A5hnV7BjoROYcqz45nBnqUa9m
+H4ygcpUQWAfOeI9kB9lrUlkb3KqZxxMQxANsDs/USxC4gELNZKsMT7ufK8gG2j+n
+/Tq2Ovldz6AupHfy0f3UEKUJsOgbKCoVL6WiW0Lzr9Nu9kYj/aHLuw7m343da7NB
+KX9pftNqikwaIe91HnpUyNXji7lENcOwif2EXT8uRBTJJ+Ea+0JJwna5x8vZGrcx
+EMlRbbvGzmQA+vr9tpaWKT/Qak86OGRubusWWjDxrQX/yPgciBJfMgI1ezVPR4vj
+9Am4rd25k4jh/K8hSRcFkKdWO/81GTaQtVVpv2hjBaaoZdHxPcWrHoNRR2ktq5XS
+7CyXPJIg1IsZImXgvBTtI/iiOPeo+TIG/2ich5KlGlIilqdDwg+R67xasn2Zcsfr
+3eip9Yx+B8WkcDe6l900bRQLpuQ/7C5Kmdlw5m5GbDxsQUj8SiScc2tBtai1V63L
+VfeIOQ41hD/WJehRBGMRzspUwNhs0FIO+QjHJW1ikWW8dJryKF/YpWr+1sTot3ri
+6yaSgvKZzsVaVPrGIxhTH8FuNvlODXgnIOfNVS0hMDE=
+-----END RSA PRIVATE KEY-----
 ```
 
 ## Interfaces:

--- a/src/CryptoShark.csproj
+++ b/src/CryptoShark.csproj
@@ -6,8 +6,8 @@
     <Nullable>disable</Nullable>
     <SignAssembly>False</SignAssembly>
     <NeutralLanguage>en</NeutralLanguage>
-    <AssemblyVersion>3.2.0</AssemblyVersion>
-    <FileVersion>3.2.0</FileVersion>
+    <AssemblyVersion>3.2.1</AssemblyVersion>
+    <FileVersion>3.2.1</FileVersion>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/AlyxSharkBite/CryptoShark</PackageProjectUrl>
     <Copyright>2025</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryUrl>https://github.com/AlyxSharkBite/CryptoShark</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <LangVersion>default</LangVersion>
-    <Version>3.2.0</Version>    
+    <Version>3.2.1</Version>    
     <Title>CryptoShark</Title>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>

--- a/src/CryptoShark.csproj
+++ b/src/CryptoShark.csproj
@@ -6,8 +6,8 @@
     <Nullable>disable</Nullable>
     <SignAssembly>False</SignAssembly>
     <NeutralLanguage>en</NeutralLanguage>
-    <AssemblyVersion>3.1.0</AssemblyVersion>
-    <FileVersion>3.1.0</FileVersion>
+    <AssemblyVersion>3.2.0</AssemblyVersion>
+    <FileVersion>3.2.0</FileVersion>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/AlyxSharkBite/CryptoShark</PackageProjectUrl>
     <Copyright>2025</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryUrl>https://github.com/AlyxSharkBite/CryptoShark</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <LangVersion>default</LangVersion>
-    <Version>3.0.0</Version>    
+    <Version>3.2.0</Version>    
     <Title>CryptoShark</Title>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>

--- a/src/CryptographicProviders/CryptoSharkEccCryptography.cs
+++ b/src/CryptographicProviders/CryptoSharkEccCryptography.cs
@@ -44,7 +44,7 @@ namespace CryptoShark.CryptographicProviders
             }
             
             var decryptionResult = _encryptor.Decrypt(record.EncryptedData, record.PublicKey, privateKey, 
-                record.Algorithm, record.Nonce, record.Signature, password);
+                record.EncryptionAlgorithm, record.HashAlgorithm, record.Nonce, record.Signature, password);
 
             if (decryptionResult.IsFailure)
                 throw new CryptographicException("Decryption Failed, see inner exception(s)", decryptionResult.Error);
@@ -66,7 +66,8 @@ namespace CryptoShark.CryptographicProviders
                 throw new ArgumentNullException(nameof(encryptionRequest));
 
             var encryptionResult = _encryptor.Encrypt(encryptionRequest.ClearData, encryptionRequest.PublicKey,
-                encryptionRequest.PrivateKey, encryptionRequest.Algorithm, encryptionRequest.Password);
+                encryptionRequest.PrivateKey, encryptionRequest.EncryptionAlgorithm, encryptionRequest.HashAlgorithm,
+                encryptionRequest.Password);
 
             if (encryptionResult.IsFailure)
                 throw new CryptographicException("Decryption Failed, see inner exception(s)", encryptionResult.Error);

--- a/src/CryptographicProviders/CryptoSharkPasswordCryptography.cs
+++ b/src/CryptographicProviders/CryptoSharkPasswordCryptography.cs
@@ -41,12 +41,12 @@ namespace CryptoShark.CryptographicProviders
                 throw new CryptographicException("Decryption Failed, see inner exception(s)", ex);
             }
 
-            var decryptionResult = _encryptor.Decrypt(record.EncryptedData, password, record.Algorithm,
-                record.Nonce, record.Salt, record.Hash, record.Iterations);
+            var decryptionResult = _encryptor.Decrypt(record.EncryptedData, password, record.EncryptionAlgorithm,
+                record.HashAlgorithm, record.Nonce, record.Salt, record.Hash, record.Iterations);
 
             if (decryptionResult.IsFailure)
                 throw new CryptographicException("Decryption Failed, see inner exception(s)", decryptionResult.Error);
-
+         
             return decryptionResult.Value.AsMemory();
         }
 
@@ -56,8 +56,8 @@ namespace CryptoShark.CryptographicProviders
             if (encryptionRequest is null)
                 throw new ArgumentNullException(nameof(encryptionRequest));
 
-            var encryptionResult = _encryptor.Encrypt(encryptionRequest.ClearData, encryptionRequest.Algorithm, 
-                encryptionRequest.Password);
+            var encryptionResult = _encryptor.Encrypt(encryptionRequest.ClearData, encryptionRequest.EncryptionAlgorithm,
+                encryptionRequest.HashAlgorithm, encryptionRequest.Password);
 
             if (encryptionResult.IsFailure)
                 throw new CryptographicException("Decryption Failed, see inner exception(s)", encryptionResult.Error);

--- a/src/CryptographicProviders/CryptoSharkRsaCryptography.cs
+++ b/src/CryptographicProviders/CryptoSharkRsaCryptography.cs
@@ -41,10 +41,10 @@ namespace CryptoShark.CryptographicProviders
             {
                 _logger?.LogError(ex, "CryptoShark:CryptoSharkRsaCryptography:Decrypt {message}", ex.Message);
                 throw new CryptographicException("Decryption Failed, see inner exception(s)", ex);
-            }
+            }            
 
-            var decryptionResult = _encryptor.Decrypt(record.EncryptedData, record.PublicKey, privateKey, record.Algorithm,
-                record.Nonce, record.Signature, record.EncryptionKey, password);
+            var decryptionResult = _encryptor.Decrypt(record.EncryptedData, record.PublicKey, privateKey, record.EncryptionAlgorithm,
+                record.HashAlgorithm, record.Nonce, record.Signature, record.EncryptionKey, password, record.RsaPadding);
 
             if (decryptionResult.IsFailure)
                 throw new CryptographicException("Decryption Failed, see inner exception(s)", decryptionResult.Error);
@@ -66,7 +66,8 @@ namespace CryptoShark.CryptographicProviders
                 throw new ArgumentNullException(nameof(encryptionRequest));
 
             var encryptionResult = _encryptor.Encrypt(encryptionRequest.ClearData, encryptionRequest.PublicKey,
-                encryptionRequest.PrivateKey, encryptionRequest.Algorithm, encryptionRequest.Password);
+                encryptionRequest.PrivateKey, encryptionRequest.EncryptionAlgorithm, encryptionRequest.HashAlgorithm,
+                encryptionRequest.Password, encryptionRequest.RsaPadding);
 
             if (encryptionResult.IsFailure)
                 throw new CryptographicException("Decryption Failed, see inner exception(s)", encryptionResult.Error);

--- a/src/Engine/HashEngine.cs
+++ b/src/Engine/HashEngine.cs
@@ -1,4 +1,5 @@
 ﻿using CryptoShark.Enums;
+using Org.BouncyCastle.Security;
 using System;
 
 
@@ -10,7 +11,9 @@ namespace CryptoShark.Engine
 
         public HashEngine(HashAlgorithm hashAlgorithm)
         {
-            _hashAlgorithm = hashAlgorithm;
+            _hashAlgorithm = hashAlgorithm == HashAlgorithm.NONE ?
+                HashAlgorithm.SHA_256 : 
+                hashAlgorithm;
         }        
 
         /// <summary>
@@ -105,67 +108,7 @@ namespace CryptoShark.Engine
 
         private Org.BouncyCastle.Crypto.IDigest GetDigest()
         {
-            dynamic digest;
-
-            switch (_hashAlgorithm)
-            {
-                case HashAlgorithm.MD5:
-                    digest = new Org.BouncyCastle.Crypto.Digests.MD5Digest();
-                    break;
-
-                case HashAlgorithm.SHA1:
-                    digest = new Org.BouncyCastle.Crypto.Digests.Sha1Digest();
-                    break;
-
-                case HashAlgorithm.SHA2_256:
-                    digest = new Org.BouncyCastle.Crypto.Digests.Sha256Digest();
-                    break;
-
-                case HashAlgorithm.SHA2_384:
-                    digest = new Org.BouncyCastle.Crypto.Digests.Sha384Digest();
-                    break;
-
-                case HashAlgorithm.SHA2_512:
-                    digest = new Org.BouncyCastle.Crypto.Digests.Sha512Digest();
-                    break;
-
-                case HashAlgorithm.SHA3_256:
-                    digest = new Org.BouncyCastle.Crypto.Digests.Sha3Digest(256);
-                    break;
-
-                case HashAlgorithm.SHA3_384:
-                    digest = new Org.BouncyCastle.Crypto.Digests.Sha3Digest(384);
-                    break;
-
-                case HashAlgorithm.SHA3_512:
-                    digest = new Org.BouncyCastle.Crypto.Digests.Sha3Digest(512);
-                    break;
-
-                case HashAlgorithm.RipeMD_128:
-                    digest = new Org.BouncyCastle.Crypto.Digests.RipeMD128Digest();
-                    break;
-
-                case HashAlgorithm.RipeMD_160:
-                    digest = new Org.BouncyCastle.Crypto.Digests.RipeMD160Digest();
-                    break;
-
-                case HashAlgorithm.RipeMD_256:
-                    digest = new Org.BouncyCastle.Crypto.Digests.RipeMD256Digest();
-                    break;
-
-                case HashAlgorithm.RipeMD_320:
-                    digest = new Org.BouncyCastle.Crypto.Digests.RipeMD320Digest();
-                    break;
-
-                case HashAlgorithm.Whirlpool:
-                    digest = new Org.BouncyCastle.Crypto.Digests.WhirlpoolDigest();
-                    break;
-
-                default:
-                    throw new ArgumentException("Invalid Hash Algorithm");
-            }
-
-            return digest;
+            return DigestUtilities.GetDigest(_hashAlgorithm.ToString());
         }       
 
         private string Base64UrlEncode(ReadOnlySpan<byte> data)

--- a/src/Enums/HashAlgorithm.cs
+++ b/src/Enums/HashAlgorithm.cs
@@ -7,83 +7,49 @@ namespace CryptoShark.Enums
     /// </summary>
     public enum HashAlgorithm : byte
     {
-        /// <summary>
-        ///     MD5 128 Bit
-        ///     https://en.wikipedia.org/wiki/MD5
-        /// </summary>
+        BLAKE2B_160,
+        BLAKE2B_256,
+        BLAKE2B_384,
+        BLAKE2B_512,
+        BLAKE2S_128,
+        BLAKE2S_160,
+        BLAKE2S_224,
+        BLAKE2S_256,
+        BLAKE3_256,
+        DSTU7564_256,
+        DSTU7564_384,
+        DSTU7564_512,
+        GOST3411,
+        GOST3411_2012_256,
+        GOST3411_2012_512,
+        KECCAK_224,
+        KECCAK_256,
+        KECCAK_288,
+        KECCAK_384,
+        KECCAK_512,
+        MD2,
+        MD4,
         MD5,
-
-        /// <summary>
-        ///     SHA-1 160 Bit
-        ///     https://en.wikipedia.org/wiki/SHA-1
-        /// </summary>
-        SHA1,
-
-        /// <summary>
-        ///     SHA-2 256 Bit
-        ///     https://en.wikipedia.org/wiki/SHA-2
-        /// </summary>
-        SHA2_256,
-
-        /// <summary>
-        ///     SHA-2 384 Bit
-        ///     https://en.wikipedia.org/wiki/SHA-2
-        /// </summary>
-        SHA2_384,
-
-        /// <summary>
-        ///     SHA-2 512 Bit
-        ///     https://en.wikipedia.org/wiki/SHA-2
-        /// </summary>
-        SHA2_512,
-
-        /// <summary>
-        ///     SHA-3 256 Bit
-        ///     https://en.wikipedia.org/wiki/SHA-3
-        /// </summary>
+        NONE,
+        RIPEMD128,
+        RIPEMD160,
+        RIPEMD256,
+        RIPEMD320,
+        SHA_1,
+        SHA_224,
+        SHA_256,
+        SHA_384,
+        SHA_512,
+        SHA_512_224,
+        SHA_512_256,
+        SHA3_224,
         SHA3_256,
-
-        /// <summary>
-        ///     SHA-3 384 Bit
-        ///     https://en.wikipedia.org/wiki/SHA-3
-        /// </summary>
         SHA3_384,
-
-        /// <summary>
-        ///     SHA-3 512 Bit
-        ///     https://en.wikipedia.org/wiki/SHA-3
-        /// </summary>
         SHA3_512,
-
-        /// <summary>
-        ///     RIPEMD 128 Bit
-        ///     https://en.wikipedia.org/wiki/RIPEMD
-        /// </summary>
-        RipeMD_128,
-
-        /// <summary>
-        ///     RIPEMD 160 Bit
-        ///     https://en.wikipedia.org/wiki/RIPEMD
-        /// </summary>
-        RipeMD_160,
-
-        /// <summary>
-        ///     RIPEMD 256 Bit
-        ///     https://en.wikipedia.org/wiki/RIPEMD
-        /// </summary>
-        RipeMD_256,
-
-        /// <summary>
-        ///     RIPEMD 320 Bit
-        ///     https://en.wikipedia.org/wiki/RIPEMD
-        /// </summary>
-        RipeMD_320,
-
-        /// <summary>
-        ///     Whirlpool 512 Bit
-        ///     https://en.wikipedia.org/wiki/Whirlpool_(hash_function)
-        /// </summary>
-        Whirlpool
-
+        SHAKE128_256,
+        SHAKE256_512,
+        SM3,
+        TIGER,
+        WHIRLPOOL
     }
 }

--- a/src/Interfaces/IEncryptionRequest.cs
+++ b/src/Interfaces/IEncryptionRequest.cs
@@ -23,7 +23,12 @@ namespace CryptoShark.Interfaces
         /// <summary>
         ///     Encryption Algorithm To Use
         /// </summary>
-        EncryptionAlgorithm Algorithm { get; }
+        EncryptionAlgorithm EncryptionAlgorithm { get; }
+
+        /// <summary>
+        ///     Hash Algorithm To Use
+        /// </summary>
+        HashAlgorithm HashAlgorithm { get; }        
     }
 
     public interface IAsymetricEncryptionRequest : IEncryptionRequest
@@ -38,5 +43,11 @@ namespace CryptoShark.Interfaces
         /// Private Key
         /// </summary>
         byte[] PrivateKey { get; }
+
+        /// <summary>
+        /// Padding (RSA Only) 
+        /// Default: OAEPWithSHA-256AndMGF1Padding
+        /// </summary>
+        string RsaPadding { get; }
     }
 }

--- a/src/Interfaces/IRecordMarker.cs
+++ b/src/Interfaces/IRecordMarker.cs
@@ -24,7 +24,7 @@ namespace CryptoShark.Interfaces
         /// <summary>
         ///     Encryption Algorithm Used
         /// </summary>       
-        public EncryptionAlgorithm Algorithm { get; }
+        public EncryptionAlgorithm EncryptionAlgorithm { get; }
     }
 
     public interface ISemetricRecordMarker : IRecordMarker

--- a/src/Record/EccCryptographyRecord.cs
+++ b/src/Record/EccCryptographyRecord.cs
@@ -48,6 +48,12 @@ namespace CryptoShark.Record
         ///     Encryption Algorithm Used
         /// </summary>
         [Required]
-        public EncryptionAlgorithm Algorithm { get; init; }
+        public EncryptionAlgorithm EncryptionAlgorithm { get; init; }
+
+        /// <summary>
+        ///     Hashing Algorithm Used
+        /// </summary>
+        [Required]
+        public HashAlgorithm HashAlgorithm { get; init; }
     }
 }

--- a/src/Record/PbeCryptographyRecord.cs
+++ b/src/Record/PbeCryptographyRecord.cs
@@ -55,6 +55,12 @@ namespace CryptoShark.Record
         ///     Encryption Algorithm Used
         /// </summary>
         [Required]
-        public EncryptionAlgorithm Algorithm { get; init; }
+        public EncryptionAlgorithm EncryptionAlgorithm { get; init; }
+
+        /// <summary>
+        ///     Hashing Algorithm Used
+        /// </summary>
+        [Required]
+        public HashAlgorithm HashAlgorithm { get; init; }
     }
 }

--- a/src/Record/RsaCryptographyRecord.cs
+++ b/src/Record/RsaCryptographyRecord.cs
@@ -2,9 +2,11 @@
 using CryptoShark.Interfaces;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace CryptoShark.Record
@@ -54,6 +56,21 @@ namespace CryptoShark.Record
         ///     Encryption Algorithm Used
         /// </summary>
         [Required]
-        public EncryptionAlgorithm Algorithm { get; init; }
+        public EncryptionAlgorithm EncryptionAlgorithm { get; init; }
+
+        /// <summary>
+        ///     Hashing Algorithm Used
+        /// </summary>
+        [Required]
+        public HashAlgorithm HashAlgorithm { get; init; }
+
+        /// <summary>
+        /// Padding 
+        /// Default: OAEPWithSHA-256AndMGF1Padding
+        /// </summary>
+        [Required]
+        [DefaultValue("OAEPWithSHA-256AndMGF1Padding")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.Never)]        
+        public string RsaPadding { get; init; }
     }
 }

--- a/src/Requests/AsymetricEncryptionRequest.cs
+++ b/src/Requests/AsymetricEncryptionRequest.cs
@@ -8,24 +8,40 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace CryptoShark.Requests
-{
+{  
     public class AsymetricEncryptionRequest : IAsymetricEncryptionRequest
     {
-        private AsymetricEncryptionRequest(byte[] publicKey, byte[] privateKey, byte[] clearData, SecureString password, EncryptionAlgorithm algorithm)
+        const string DEFAULT_RSA_PADDING = "OAEPWithSHA-256AndMGF1Padding";
+
+        private AsymetricEncryptionRequest(byte[] publicKey, byte[] privateKey, byte[] clearData, SecureString password, 
+            EncryptionAlgorithm encryptionAlgorithm, HashAlgorithm hashAlgorithm, string rsaPadding = null)
         {
             PublicKey = publicKey;
             PrivateKey = privateKey;
             ClearData = clearData;
             Password = password;
-            Algorithm = algorithm;
+            EncryptionAlgorithm = encryptionAlgorithm;
+            HashAlgorithm = hashAlgorithm;
+
+            if(String.IsNullOrEmpty(rsaPadding))
+                RsaPadding = DEFAULT_RSA_PADDING;
+            else
+                RsaPadding = rsaPadding;
         }
 
-        private AsymetricEncryptionRequest(byte[] publicKey, byte[] privateKey, byte[] clearData, string password, EncryptionAlgorithm algorithm)
+        private AsymetricEncryptionRequest(byte[] publicKey, byte[] privateKey, byte[] clearData, string password, 
+            EncryptionAlgorithm encryptionAlgorithm, HashAlgorithm hashAlgorithm, string rsaPadding = null)
         {
             PublicKey = publicKey;
             PrivateKey = privateKey;
             ClearData = clearData;            
-            Algorithm = algorithm;
+            EncryptionAlgorithm = encryptionAlgorithm;
+            HashAlgorithm = hashAlgorithm;           
+
+            if (String.IsNullOrEmpty(rsaPadding))
+                RsaPadding = DEFAULT_RSA_PADDING;
+            else
+                RsaPadding = rsaPadding;
 
             Password = new SecureString();
             foreach (var c in password.ToCharArray())
@@ -47,46 +63,20 @@ namespace CryptoShark.Requests
         public SecureString Password { get; private set; }
 
         /// <inheritdoc />
-        public EncryptionAlgorithm Algorithm { get; private set; }
+        public EncryptionAlgorithm EncryptionAlgorithm { get; private set; }
 
-        /// <summary>
-        /// Create's the Encryption Request
-        /// </summary>
-        /// <param name="clearData"></param>
-        /// <param name="password"></param>
-        /// <param name="algorithm"></param>
-        /// <returns></returns>
-        public static IAsymetricEncryptionRequest CreateRequest(byte[] publicKey, byte[] privateKey, byte[] clearData, SecureString password, EncryptionAlgorithm algorithm)
-            => new AsymetricEncryptionRequest(publicKey, privateKey, clearData, password, algorithm);
+        /// <inheritdoc />
+        public HashAlgorithm HashAlgorithm { get; private set; }
 
-        /// <summary>
-        /// Create's the Encryption Request
-        /// </summary>
-        /// <param name="clearData"></param>
-        /// <param name="password"></param>
-        /// <param name="algorithm"></param>
-        /// <returns></returns>
-        public static IAsymetricEncryptionRequest CreateRequest(ReadOnlySpan<byte> publicKey, ReadOnlySpan<byte> privateKey, ReadOnlyMemory<byte> clearData, SecureString password, EncryptionAlgorithm algorithm)
-            => new AsymetricEncryptionRequest(publicKey.ToArray(), privateKey.ToArray(), clearData.ToArray(), password, algorithm);
+        /// <inheritdoc />
+        public string RsaPadding { get; private set; }
 
-        /// <summary>
-        /// Create's the Encryption Request
-        /// </summary>
-        /// <param name="clearData"></param>
-        /// <param name="password"></param>
-        /// <param name="algorithm"></param>
-        /// <returns></returns>
-        public static IAsymetricEncryptionRequest CreateRequest(byte[] publicKey, byte[] privateKey, byte[] clearData, string password, EncryptionAlgorithm algorithm)
-            => new AsymetricEncryptionRequest(publicKey, privateKey, clearData, password, algorithm);
 
-        /// <summary>
-        /// Create's the Encryption Request
-        /// </summary>
-        /// <param name="clearData"></param>
-        /// <param name="password"></param>
-        /// <param name="algorithm"></param>
-        /// <returns></returns>
-        public static IAsymetricEncryptionRequest CreateRequest(ReadOnlySpan<byte> publicKey, ReadOnlySpan<byte> privateKey, ReadOnlyMemory<byte> clearData, string password, EncryptionAlgorithm algorithm)
-            => new AsymetricEncryptionRequest(publicKey.ToArray(), privateKey.ToArray(), clearData.ToArray(), password, algorithm);
+        public static IAsymetricEncryptionRequest CreateRequest(byte[] publicKey, byte[] privateKey, byte[] clearData, SecureString password, EncryptionAlgorithm encryptionAlgorithm, HashAlgorithm hashAlgorithm, string rsaPadding = null)
+            => new AsymetricEncryptionRequest(publicKey, privateKey, clearData, password, encryptionAlgorithm, hashAlgorithm, rsaPadding);
+        
+        public static IAsymetricEncryptionRequest CreateRequest(byte[] publicKey, byte[] privateKey, byte[] clearData, string password, EncryptionAlgorithm encryptionAlgorithm, HashAlgorithm hashAlgorithm, string rsaPadding = null)
+            => new AsymetricEncryptionRequest(publicKey, privateKey, clearData, password, encryptionAlgorithm, hashAlgorithm, rsaPadding);
+     
     }
 }

--- a/src/Requests/SemetricEncryptionRequest.cs
+++ b/src/Requests/SemetricEncryptionRequest.cs
@@ -11,17 +11,21 @@ namespace CryptoShark.Requests
 {
     public class SemetricEncryptionRequest : IEncryptionRequest
     {
-        private SemetricEncryptionRequest(byte[] clearData, SecureString password, EncryptionAlgorithm algorithm)
+        private SemetricEncryptionRequest(byte[] clearData, SecureString password, EncryptionAlgorithm encryptionAlgorithm,
+            CryptoShark.Enums.HashAlgorithm hashAlgorithm)
         {
             ClearData = clearData;
             Password = password;
-            Algorithm = algorithm;
+            EncryptionAlgorithm = encryptionAlgorithm;
+            HashAlgorithm = hashAlgorithm;
         }
 
-        private SemetricEncryptionRequest(byte[] clearData, string password, EncryptionAlgorithm algorithm)
+        private SemetricEncryptionRequest(byte[] clearData, string password, EncryptionAlgorithm encryptionAlgorithm,
+            CryptoShark.Enums.HashAlgorithm hashAlgorithm)
         {
             ClearData = clearData;            
-            Algorithm = algorithm;
+            EncryptionAlgorithm = encryptionAlgorithm;
+            HashAlgorithm = hashAlgorithm;
 
             Password = new SecureString();
             foreach (var c in password.ToCharArray())
@@ -37,26 +41,15 @@ namespace CryptoShark.Requests
         public SecureString Password { get; private set; }
 
         /// <inheritdoc />
-        public EncryptionAlgorithm Algorithm { get; private set; }
+        public EncryptionAlgorithm EncryptionAlgorithm { get; private set; }
 
-        /// <summary>
-        /// Create's the Encryption Request
-        /// </summary>
-        /// <param name="clearData"></param>
-        /// <param name="password"></param>
-        /// <param name="algorithm"></param>
-        /// <returns></returns>
-        public static IEncryptionRequest CreateRequest(byte[] clearData, SecureString password, EncryptionAlgorithm algorithm) 
-            => new SemetricEncryptionRequest(clearData, password, algorithm);
-
-        /// <summary>
-        /// Create's the Encryption Request
-        /// </summary>
-        /// <param name="clearData"></param>
-        /// <param name="password"></param>
-        /// <param name="algorithm"></param>
-        /// <returns></returns>
-        public static IEncryptionRequest CreateRequest(byte[] clearData, string password, EncryptionAlgorithm algorithm)
-            => new SemetricEncryptionRequest(clearData, password, algorithm);
+        /// <inheritdoc />
+        public HashAlgorithm HashAlgorithm { get; private set; }
+        
+        public static IEncryptionRequest CreateRequest(byte[] clearData, SecureString password, EncryptionAlgorithm encryptionAlgorithm, CryptoShark.Enums.HashAlgorithm hashAlgorithm) 
+            => new SemetricEncryptionRequest(clearData, password, encryptionAlgorithm, hashAlgorithm);
+        
+        public static IEncryptionRequest CreateRequest(byte[] clearData, string password, EncryptionAlgorithm encryptionAlgorithm, CryptoShark.Enums.HashAlgorithm hashAlgorithm)
+            => new SemetricEncryptionRequest(clearData, password, encryptionAlgorithm, hashAlgorithm);
     }
 }

--- a/src/Utilities/AsymmetricCipherUtilities.cs
+++ b/src/Utilities/AsymmetricCipherUtilities.cs
@@ -1,4 +1,5 @@
-﻿using Org.BouncyCastle.Asn1;
+﻿using CryptoShark.Enums;
+using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.X9;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Generators;
@@ -15,6 +16,9 @@ using System.Threading.Tasks;
 
 namespace CryptoShark.Utilities
 {
+    /// <summary>
+    /// Low level Asymmetric Cipher Utilities
+    /// </summary>
     internal class AsymmetricCipherUtilities
     {
         private readonly SecureRandom _random = new SecureRandom();
@@ -37,6 +41,16 @@ namespace CryptoShark.Utilities
             ecKeyPairGen.Init(ecKeyGenParams);
             AsymmetricCipherKeyPair ecKeyPair = ecKeyPairGen.GenerateKeyPair();
             return ecKeyPair;
+        }
+
+        public AsymmetricCipherKeyPair GenerateRsaKeyPair(int keySize)
+        {
+            var keyPairGenerator = new RsaKeyPairGenerator();
+            var keyGenParams = new KeyGenerationParameters(_random, keySize);
+            keyPairGenerator.Init(keyGenParams);
+            AsymmetricCipherKeyPair rsaKeyPair = keyPairGenerator.GenerateKeyPair();
+
+            return rsaKeyPair;
         }
 
         public byte[] WriteKeyPair(AsymmetricCipherKeyPair keyPair, SecureString password)
@@ -71,9 +85,9 @@ namespace CryptoShark.Utilities
             return keyPair;
         }
 
-        public AsymmetricKeyParameter ReadPublicKey(byte[] privateKeyData)
+        public AsymmetricKeyParameter ReadPublicKey(byte[] publicKeyData)
         {
-            using MemoryStream pemStream = new MemoryStream(privateKeyData);
+            using MemoryStream pemStream = new MemoryStream(publicKeyData);
             using StreamReader reader = new StreamReader(pemStream);
             using PemReader pemReader = new PemReader(reader);
             var publicKey = (AsymmetricKeyParameter)pemReader.ReadObject();

--- a/src/Utilities/CryptoSharkUtilities.cs
+++ b/src/Utilities/CryptoSharkUtilities.cs
@@ -71,9 +71,8 @@ namespace CryptoShark.Utilities
             {
                 lock (_lock)
                 {
-                    using var rsa = RSACng.Create((int)keySize);
-                    return rsa.ExportEncryptedPkcs8PrivateKey(_secureStringUtilities.SecureStringToString(password),
-                       new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA384, 10000));
+                    var keyPair = _asymmetricCipherUtilities.GenerateRsaKeyPair((int)keySize);
+                    return _asymmetricCipherUtilities.WriteKeyPair(keyPair, password);
                 }
             }
             catch (Exception ex)
@@ -89,10 +88,8 @@ namespace CryptoShark.Utilities
             {
                 lock (_lock)
                 {
-                    using var rsa = RSACng.Create();
-
-                    rsa.ImportEncryptedPkcs8PrivateKey(_secureStringUtilities.SecureStringToString(password), encryptedRsaKey, out var _);
-                    return rsa.ExportRSAPublicKey();
+                    var keyPair = _asymmetricCipherUtilities.ReadKeyPair(encryptedRsaKey.ToArray(), password);
+                    return _asymmetricCipherUtilities.WritePublicKey(keyPair.Public);
                 }
             }
             catch (Exception ex)

--- a/tests/CryptoSharkTests/CryptographicProviderTests/CryptoSharkCryptographyUtilityTest.cs
+++ b/tests/CryptoSharkTests/CryptographicProviderTests/CryptoSharkCryptographyUtilityTest.cs
@@ -79,7 +79,8 @@ public class Create
     {
         var provider = CryptoSharkCryptographyUtilities.Create();
 
-        Assert.Throws<CryptographicException>(() => provider.HashBytes(_sampleData, (CryptoShark.Enums.HashAlgorithm)16, CryptoShark.Enums.StringEncoding.Hex));
+        Assert.Throws<CryptographicException>(() => provider.HashBytes(_sampleData, (CryptoShark.Enums.HashAlgorithm)Byte.MaxValue, 
+            CryptoShark.Enums.StringEncoding.Hex));
     }
 
     [TestCaseSource(nameof(CreateLoggers))]
@@ -96,7 +97,7 @@ public class Create
     {
         var provider = CryptoSharkCryptographyUtilities.Create();
 
-        Assert.Throws<CryptographicException>(() => provider.HashBytes(_sampleData, (CryptoShark.Enums.HashAlgorithm)16));
+        Assert.Throws<CryptographicException>(() => provider.HashBytes(_sampleData, (CryptoShark.Enums.HashAlgorithm) Byte.MaxValue));
     }
 
     private static Array CreateLoggers()

--- a/tests/CryptoSharkTests/CryptographicProviderTests/CryptoSharkEccCryptographyTests.cs
+++ b/tests/CryptoSharkTests/CryptographicProviderTests/CryptoSharkEccCryptographyTests.cs
@@ -53,7 +53,7 @@ public class CryptoSharkEccCryptographyTests
         Assert.That(privateKey.IsEmpty, Is.False);
 
         var request = AsymetricEncryptionRequest.CreateRequest(publicKey.ToArray(), privateKey.ToArray(), _sampleData, 
-            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes);
+            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes, CryptoShark.Enums.HashAlgorithm.SHA3_256);
 
         var encrypted = provider.Encrypt(request);
         Assert.That(encrypted.IsEmpty, Is.False);
@@ -96,7 +96,7 @@ public class CryptoSharkEccCryptographyTests
         Assert.That(privateKey.IsEmpty, Is.False);
 
         var request = AsymetricEncryptionRequest.CreateRequest(publicKey.ToArray(), privateKey.ToArray(), _sampleData,
-            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes);
+            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes, CryptoShark.Enums.HashAlgorithm.SHA3_256);
 
         Assert.Throws<CryptographicException>(() => provider.Encrypt(request));
 
@@ -115,7 +115,7 @@ public class CryptoSharkEccCryptographyTests
             CryptoShark.Enums.CryptographyType.EllipticalCurveCryptography);
        
         var request = AsymetricEncryptionRequest.CreateRequest(publicKey.ToArray(), privateKey.ToArray(), _sampleData,
-            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes);
+            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes, CryptoShark.Enums.HashAlgorithm.SHA3_256);
 
         var encrypted = provider.Encrypt(request);
         Assert.That(encrypted.IsEmpty, Is.False);
@@ -137,7 +137,7 @@ public class CryptoSharkEccCryptographyTests
             CryptoShark.Enums.CryptographyType.EllipticalCurveCryptography);
 
         var request = AsymetricEncryptionRequest.CreateRequest(publicKey.ToArray(), privateKey.ToArray(), _sampleData,
-            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes);
+            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes, CryptoShark.Enums.HashAlgorithm.SHA3_256);
 
         var encrypted = provider.Encrypt(request);
         Assert.That(encrypted.IsEmpty, Is.False);
@@ -162,7 +162,7 @@ public class CryptoSharkEccCryptographyTests
             CryptoShark.Enums.CryptographyType.EllipticalCurveCryptography);
 
         var request = AsymetricEncryptionRequest.CreateRequest(publicKey.ToArray(), privateKey.ToArray(), _sampleData,
-            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes);
+            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes, CryptoShark.Enums.HashAlgorithm.SHA3_256);
 
         var encrypted = provider.Encrypt(request);
         Assert.That(encrypted.IsEmpty, Is.False);

--- a/tests/CryptoSharkTests/CryptographicProviderTests/CryptoSharkPasswordCryptographyTests.cs
+++ b/tests/CryptoSharkTests/CryptographicProviderTests/CryptoSharkPasswordCryptographyTests.cs
@@ -38,7 +38,8 @@ public class CryptoSharkPasswordCryptographyTests
     public void EncryptionSuccessTests(ILogger logger)
     {
         var provider = CryptoSharkPasswordCryptography.Create(logger);
-        var request = SemetricEncryptionRequest.CreateRequest(_sampleData, _password, CryptoShark.Enums.EncryptionAlgorithm.Aes);
+        var request = SemetricEncryptionRequest.CreateRequest(_sampleData, _password, 
+            CryptoShark.Enums.EncryptionAlgorithm.Aes, CryptoShark.Enums.HashAlgorithm.SHA3_256);
 
         var encrypted = provider.Encrypt(request);
         Assert.That(encrypted.IsEmpty, Is.False);
@@ -57,7 +58,8 @@ public class CryptoSharkPasswordCryptographyTests
     public void EncryptionFailsInvalidParamsTests(ILogger logger)
     {
         var provider = CryptoSharkPasswordCryptography.Create(logger);
-        var request = SemetricEncryptionRequest.CreateRequest(_sampleData, _password, (CryptoShark.Enums.EncryptionAlgorithm) 15);
+        var request = SemetricEncryptionRequest.CreateRequest(_sampleData, _password, 
+            (CryptoShark.Enums.EncryptionAlgorithm) 15, CryptoShark.Enums.HashAlgorithm.SHA3_256);
 
         Assert.Throws<CryptographicException>(() => provider.Encrypt(request));
     }
@@ -66,7 +68,9 @@ public class CryptoSharkPasswordCryptographyTests
     public void DecryptionSuccessTests(ILogger logger)
     {
         var provider = CryptoSharkPasswordCryptography.Create(logger);
-        var request = SemetricEncryptionRequest.CreateRequest(_sampleData, _password, CryptoShark.Enums.EncryptionAlgorithm.Aes);
+        var request = SemetricEncryptionRequest.CreateRequest(_sampleData, _password, 
+            CryptoShark.Enums.EncryptionAlgorithm.Aes, CryptoShark.Enums.HashAlgorithm.SHA3_256);
+
         var encrypted = provider.Encrypt(request);
 
         var decrypted = provider.Decrypt(encrypted, StringToSecureString(_password));

--- a/tests/CryptoSharkTests/CryptographicProviderTests/CryptoSharkRsaCryptographyTests.cs
+++ b/tests/CryptoSharkTests/CryptographicProviderTests/CryptoSharkRsaCryptographyTests.cs
@@ -50,7 +50,7 @@ public class CryptoSharkRsaCryptographyTests
         Assert.That(privateKey.IsEmpty, Is.False);
 
         var request = AsymetricEncryptionRequest.CreateRequest(publicKey.ToArray(), privateKey.ToArray(), _sampleData,
-            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes);
+            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes, CryptoShark.Enums.HashAlgorithm.SHA3_256);
 
         var encrypted = provider.Encrypt(request);
         Assert.That(encrypted.IsEmpty, Is.False);
@@ -91,7 +91,7 @@ public class CryptoSharkRsaCryptographyTests
         Assert.That(privateKey.IsEmpty, Is.False);
 
         var request = AsymetricEncryptionRequest.CreateRequest(publicKey.ToArray(), privateKey.ToArray(), _sampleData,
-            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes);
+            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes, CryptoShark.Enums.HashAlgorithm.SHA3_256);
 
         Assert.Throws<CryptographicException>(() => provider.Encrypt(request));
 
@@ -113,7 +113,7 @@ public class CryptoSharkRsaCryptographyTests
         Assert.That(privateKey.IsEmpty, Is.False);
 
         var request = AsymetricEncryptionRequest.CreateRequest(publicKey.ToArray(), privateKey.ToArray(), _sampleData,
-            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes);
+            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes, CryptoShark.Enums.HashAlgorithm.SHA3_256);
 
         var encrypted = provider.Encrypt(request);
         Assert.That(encrypted.IsEmpty, Is.False);
@@ -138,7 +138,7 @@ public class CryptoSharkRsaCryptographyTests
         Assert.That(privateKey.IsEmpty, Is.False);
 
         var request = AsymetricEncryptionRequest.CreateRequest(publicKey.ToArray(), privateKey.ToArray(), _sampleData,
-            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes);
+            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes, CryptoShark.Enums.HashAlgorithm.SHA3_256);
 
         var privateKeyArray = privateKey.ToArray();
 
@@ -163,7 +163,7 @@ public class CryptoSharkRsaCryptographyTests
         Assert.That(privateKey.IsEmpty, Is.False);
 
         var request = AsymetricEncryptionRequest.CreateRequest(publicKey.ToArray(), privateKey.ToArray(), _sampleData,
-            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes);
+            _password, CryptoShark.Enums.EncryptionAlgorithm.Aes, CryptoShark.Enums.HashAlgorithm.SHA3_256);
 
         var privateKeyArray = new byte[privateKey.Length];
 

--- a/tests/CryptoSharkTests/EngineTests/EccEncryptionEngineTests.cs
+++ b/tests/CryptoSharkTests/EngineTests/EccEncryptionEngineTests.cs
@@ -46,17 +46,19 @@ namespace CryptoSharkTests.EngineTests
             var eccPrivateKey = _cryptoSharkUtilities.CreateEccKey(ECCurve.NamedCurves.nistP384, _password).Value;
             var eccPublicKey = _cryptoSharkUtilities.GetEccPublicKey(eccPrivateKey, _password).Value;
 
-            var encrypted = eccEncryption.Encrypt(_sampleData, eccPublicKey, eccPrivateKey, encryptionAlgorithm, _password);
+            var encrypted = eccEncryption.Encrypt(_sampleData, eccPublicKey, eccPrivateKey, encryptionAlgorithm,
+                CryptoShark.Enums.HashAlgorithm.SHA3_256, _password);
+
             Assert.That(encrypted.IsSuccess, Is.True);
             Assert.That(encrypted.Value, Is.Not.Null);
-            Assert.That(encrypted.Value.Algorithm, Is.EqualTo(encryptionAlgorithm));
+            Assert.That(encrypted.Value.EncryptionAlgorithm, Is.EqualTo(encryptionAlgorithm));
             Assert.That(encrypted.Value.Nonce, Is.Not.Null);
             Assert.That(encrypted.Value.PublicKey, Is.Not.Null);
             Assert.That(encrypted.Value.EncryptedData, Is.Not.Null);
             Assert.That(encrypted.Value.Signature, Is.Not.Null);
 
             var decrypted = eccEncryption.Decrypt(encrypted.Value.EncryptedData, eccPublicKey, eccPrivateKey, 
-                encryptionAlgorithm, encrypted.Value.Nonce, encrypted.Value.Signature, _password);
+                encryptionAlgorithm, encrypted.Value.HashAlgorithm, encrypted.Value.Nonce, encrypted.Value.Signature, _password);
 
             Assert.That(encrypted.IsSuccess, Is.True);
             Assert.That(decrypted.Value.SequenceEqual(_sampleData), Is.True);

--- a/tests/CryptoSharkTests/EngineTests/PbEncryptionEngineTests.cs
+++ b/tests/CryptoSharkTests/EngineTests/PbEncryptionEngineTests.cs
@@ -41,10 +41,11 @@ namespace CryptoSharkTests.EngineTests
         {
             PBEncryption rsaEncryption = new PBEncryption(_mockLogger.Object);           
 
-            var encrypted = rsaEncryption.Encrypt(_sampleData, encryptionAlgorithm, _password);
+            var encrypted = rsaEncryption.Encrypt(_sampleData, encryptionAlgorithm, HashAlgorithm.SHA3_256, _password);
+
             Assert.That(encrypted.IsSuccess, Is.True);
             Assert.That(encrypted.Value, Is.Not.Null);
-            Assert.That(encrypted.Value.Algorithm, Is.EqualTo(encryptionAlgorithm));
+            Assert.That(encrypted.Value.EncryptionAlgorithm, Is.EqualTo(encryptionAlgorithm));
             Assert.That(encrypted.Value.Nonce, Is.Not.Null);
             Assert.That(encrypted.Value.Hash, Is.Not.Null);
             Assert.That(encrypted.Value.Salt, Is.Not.Null);
@@ -52,7 +53,8 @@ namespace CryptoSharkTests.EngineTests
             Assert.That(encrypted.Value.Iterations, Is.GreaterThan(0));
 
             var decrypted = rsaEncryption.Decrypt(encrypted.Value.EncryptedData, _password, encryptionAlgorithm,
-                encrypted.Value.Nonce, encrypted.Value.Salt, encrypted.Value.Hash, encrypted.Value.Iterations);
+                encrypted.Value.HashAlgorithm, encrypted.Value.Nonce, encrypted.Value.Salt, encrypted.Value.Hash, 
+                encrypted.Value.Iterations);
 
             Assert.That(encrypted.IsSuccess, Is.True);
             Assert.That(decrypted.Value.SequenceEqual(_sampleData), Is.True);

--- a/tests/CryptoSharkTests/EngineTests/RsaEncryptionEngineTests.cs
+++ b/tests/CryptoSharkTests/EngineTests/RsaEncryptionEngineTests.cs
@@ -43,10 +43,12 @@ namespace CryptoSharkTests.EngineTests
             var rsaPrivateKey = _cryptoSharkUtilities.CreateRsaKey(RsaKeySize.KeySize1024, _password).Value;
             var rsaPublicKey = _cryptoSharkUtilities.GetRsaPublicKey(rsaPrivateKey, _password).Value;
 
-            var encrypted = rsaEncryption.Encrypt(_sampleData, rsaPublicKey, rsaPrivateKey, encryptionAlgorithm, _password);
+            var encrypted = rsaEncryption.Encrypt(_sampleData, rsaPublicKey, rsaPrivateKey, encryptionAlgorithm, HashAlgorithm.SHA3_256,
+                _password, null);
+
             Assert.That(encrypted.IsSuccess, Is.True);
             Assert.That(encrypted.Value, Is.Not.Null);
-            Assert.That(encrypted.Value.Algorithm, Is.EqualTo(encryptionAlgorithm));
+            Assert.That(encrypted.Value.EncryptionAlgorithm, Is.EqualTo(encryptionAlgorithm));
             Assert.That(encrypted.Value.Nonce, Is.Not.Null);
             Assert.That(encrypted.Value.EncryptionKey, Is.Not.Null);
             Assert.That(encrypted.Value.EncryptedData, Is.Not.Null);
@@ -54,7 +56,8 @@ namespace CryptoSharkTests.EngineTests
             Assert.That(encrypted.Value.PublicKey, Is.Not.Null);
 
             var decrypted = rsaEncryption.Decrypt(encrypted.Value.EncryptedData, rsaPublicKey, rsaPrivateKey, encryptionAlgorithm,
-                encrypted.Value.Nonce, encrypted.Value.Signature, encrypted.Value.EncryptionKey, _password);
+                encrypted.Value.HashAlgorithm, encrypted.Value.Nonce, encrypted.Value.Signature, encrypted.Value.EncryptionKey,
+                _password, null);
 
             Assert.That(encrypted.IsSuccess, Is.True);
             Assert.That(decrypted.Value.SequenceEqual(_sampleData), Is.True);

--- a/tests/CryptoSharkTests/UtilityTests/RecordSerializerTests.cs
+++ b/tests/CryptoSharkTests/UtilityTests/RecordSerializerTests.cs
@@ -37,7 +37,7 @@ namespace CryptoSharkTests.UtilityTests
             Assert.That(newRecord.Signature.SequenceEqual(record.Signature), Is.True);
             Assert.That(newRecord.EncryptedData.SequenceEqual(record.EncryptedData), Is.True);
             Assert.That(newRecord.Nonce.SequenceEqual(record.Nonce), Is.True);
-            Assert.That(newRecord.Algorithm == record.Algorithm, Is.True);
+            Assert.That(newRecord.EncryptionAlgorithm == record.EncryptionAlgorithm, Is.True);
 
         }
 
@@ -57,7 +57,7 @@ namespace CryptoSharkTests.UtilityTests
             Assert.That(newRecord.Salt.SequenceEqual(record.Salt), Is.True);
             Assert.That(newRecord.EncryptedData.SequenceEqual(record.EncryptedData), Is.True);
             Assert.That(newRecord.Nonce.SequenceEqual(record.Nonce), Is.True);
-            Assert.That(newRecord.Algorithm == record.Algorithm, Is.True);
+            Assert.That(newRecord.EncryptionAlgorithm == record.EncryptionAlgorithm, Is.True);
             Assert.That(newRecord.Iterations == record.Iterations, Is.True);
 
         }
@@ -79,14 +79,14 @@ namespace CryptoSharkTests.UtilityTests
             Assert.That(newRecord.Signature.SequenceEqual(record.Signature), Is.True);
             Assert.That(newRecord.EncryptedData.SequenceEqual(record.EncryptedData), Is.True);
             Assert.That(newRecord.Nonce.SequenceEqual(record.Nonce), Is.True);
-            Assert.That(newRecord.Algorithm == record.Algorithm, Is.True);
+            Assert.That(newRecord.EncryptionAlgorithm == record.EncryptionAlgorithm, Is.True);
         }
 
         private static EccCryptographyRecord CreateEccCryptographyRecord()
         {
             return new EccCryptographyRecord
             {
-                Algorithm = CryptoShark.Enums.EncryptionAlgorithm.Aes,
+                EncryptionAlgorithm = CryptoShark.Enums.EncryptionAlgorithm.Aes,
                 PublicKey = GenerateBytes(256),
                 Signature = GenerateBytes(128),
                 EncryptedData = GenerateBytes(4096),
@@ -98,7 +98,7 @@ namespace CryptoSharkTests.UtilityTests
         {
             return new PbeCryptographyRecord
             {
-                Algorithm = CryptoShark.Enums.EncryptionAlgorithm.Aes,
+                EncryptionAlgorithm = CryptoShark.Enums.EncryptionAlgorithm.Aes,
                 EncryptedData = GenerateBytes(4096),
                 Nonce = GenerateBytes(16),
                 Hash = GenerateBytes(96),
@@ -111,7 +111,7 @@ namespace CryptoSharkTests.UtilityTests
         {
             return new RsaCryptographyRecord
             {
-                Algorithm = CryptoShark.Enums.EncryptionAlgorithm.Aes,
+                EncryptionAlgorithm = CryptoShark.Enums.EncryptionAlgorithm.Aes,
                 EncryptedData = GenerateBytes(4096),
                 EncryptionKey = GenerateBytes(112),
                 PublicKey = GenerateBytes(248),


### PR DESCRIPTION
**Version 3.2.0**
* Updated RSA Keys to use Encrypted PEM format same as ECC Keys
* Replaced all .Net Rsa Cryptography Next Generation (CNG) with BouncyCastle code

**Version 3.2.1**
* Internal code updates to mke future enhaemnts easier
* Exposed all the internal parts allowing supplying the desired options
    * Hash Alorythm for verifying data integrity can now be chosen
    * RSA Padding for RSA Encryption can now be set with stanard string 
        * Example: 'OAEPWithSHA-256AndMGF1Padding'